### PR TITLE
fixed mean diff and enhanced moving average

### DIFF
--- a/MAX30100.h
+++ b/MAX30100.h
@@ -64,7 +64,9 @@ SOFTWARE.
 #define PULSE_GO_DOWN_THRESHOLD     1
 
 #define PULSE_BPM_SAMPLE_SIZE       10 //Moving average size
-
+#define PULSE_BEAT_DURATION_RST   2500 // Time in ms to reset the moving avg
+#define PULSE_MAX_VALUE            220
+#define PULSE_MIN_VALUE             50
 
 
 


### PR DESCRIPTION
Hello,

The mean diff values array are not initialized, so it can get garbage values from memory and make the balance intensities crazy. It is fixed by memsetting at the constructor.

The moving average was enhanced by first checking if the last pulse ocurred long ago (example: the finger was removed and then put back again in the sensor) to reset the moving average array. Then, it is checked if the values of the BPM are out of bounds (50 <= BPM <= 220), so they can be ignored and not added to the moving average. Finally, the moving average sum was enhanced to avoid unnecessary calculations.